### PR TITLE
Reset process locale after QCoreApplication creation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,6 +91,8 @@ PLUGIN_API int XPluginStart(char *outName, char *outSig, char *outDesc)
   // Create application object which is needed for the server thread event queue
   int argc = 0;
   app = new atools::gui::ConsoleApplication(argc, nullptr);
+  // See http://stackoverflow.com/questions/25661295/why-does-qcoreapplication-call-setlocalelc-all-by-default-on-unix-linux
+  setlocale(LC_NUMERIC, "C");
   QCoreApplication::setApplicationName("Little Xpconnect");
   QCoreApplication::setOrganizationName("ABarthel");
   QCoreApplication::setOrganizationDomain("littlenavmap.org");


### PR DESCRIPTION
Fixes https://github.com/albar965/littlenavmap/issues/983

Not sure about side effects on Mac/Windows, though.